### PR TITLE
chore: remove 'use strict' invocation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,30 +1,8 @@
 {
   "name": "js-quiz-starter",
   "version": "1.0.0",
-  "lockfileVersion": 2,
+  "lockfileVersion": 1,
   "requires": true,
-  "packages": {
-    "": {
-      "name": "js-quiz-starter",
-      "version": "1.0.0",
-      "license": "MIT",
-      "devDependencies": {
-        "prettier": "^2.2.1"
-      }
-    },
-    "node_modules/prettier": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
-      "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    }
-  },
   "dependencies": {
     "prettier": {
       "version": "2.2.1",

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import { quizData } from './data.js';
 import { initWelcomePage } from './pages/welcomePage.js';
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /*
  The constants file is used to store anything 
  that multiple files use, that should ALWAYS be the same

--- a/src/data.js
+++ b/src/data.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /* Program Data
 
   in this file you can declare variables to store important data for your program

--- a/src/pages/questionPage.js
+++ b/src/pages/questionPage.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import {
   ANSWERS_LIST_ID,
   NEXT_QUESTION_BUTTON_ID,

--- a/src/pages/welcomePage.js
+++ b/src/pages/welcomePage.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import { USER_INTERFACE_ID, START_QUIZ_BUTTON_ID } from '../constants.js';
 import { createWelcomeElement } from '../views/welcomeView.js';
 import { initQuestionPage } from './questionPage.js';

--- a/src/views/answerView.js
+++ b/src/views/answerView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 /**
  * Create an Answer element
  * @returns {Element}

--- a/src/views/questionView.js
+++ b/src/views/questionView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import { ANSWERS_LIST_ID } from '../constants.js';
 import { NEXT_QUESTION_BUTTON_ID } from '../constants.js';
 

--- a/src/views/welcomeView.js
+++ b/src/views/welcomeView.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import { START_QUIZ_BUTTON_ID } from '../constants.js';
 
 /**


### PR DESCRIPTION
With ES6, the entire contents of JavaScript modules are automatically in strict mode, with no statement needed to initiate it.